### PR TITLE
add normal rendering into neus

### DIFF
--- a/systems/neus.py
+++ b/systems/neus.py
@@ -143,10 +143,12 @@ class NeuSSystem(BaseSystem):
         W, H = self.config.dataset.img_wh
         img = out['comp_rgb'].view(H, W, 3)
         depth = out['depth'].view(H, W)
+        normal = out['normal'].view(H, W, 3)
         opacity = out['opacity'].view(H, W)
         self.save_image_grid(f"it{self.global_step}-{batch['index'][0].item()}.png", [
             {'type': 'rgb', 'img': batch['rgb'].view(H, W, 3), 'kwargs': {'data_format': 'HWC'}},
             {'type': 'rgb', 'img': img, 'kwargs': {'data_format': 'HWC'}},
+            {'type': 'rgb', 'img': normal, 'kwargs': {'data_format': 'HWC'}},
             {'type': 'grayscale', 'img': depth, 'kwargs': {}},
             {'type': 'grayscale', 'img': opacity, 'kwargs': {'cmap': None, 'data_range': (0, 1)}}
         ])
@@ -183,10 +185,12 @@ class NeuSSystem(BaseSystem):
         W, H = self.config.dataset.img_wh
         img = out['comp_rgb'].view(H, W, 3)
         depth = out['depth'].view(H, W)
+        normal = out['normal'].view(H, W, 3)
         opacity = out['opacity'].view(H, W)
         self.save_image_grid(f"it{self.global_step}-test/{batch['index'][0].item()}.png", [
             {'type': 'rgb', 'img': batch['rgb'].view(H, W, 3), 'kwargs': {'data_format': 'HWC'}},
             {'type': 'rgb', 'img': img, 'kwargs': {'data_format': 'HWC'}},
+            {'type': 'rgb', 'img': normal, 'kwargs': {'data_format': 'HWC'}},
             {'type': 'grayscale', 'img': depth, 'kwargs': {}},
             {'type': 'grayscale', 'img': opacity, 'kwargs': {'cmap': None, 'data_range': (0, 1)}}
         ])


### PR DESCRIPTION
I haven't yet managed to get things working with monocular cues over on PR #21 . I've been going through the Neuris and MonoSDF papers/repos (very similar approaches, just slight differences in implementation details/filtering) to see what may be going wrong. In the meantime, I wanted to contribute something so I'll opened this PR to add normal rendering to the NeUS system/model.

I did some timing and found that without normal rendering on the lego scene without a mask it took around 15 minutes
Doing the naive implementation

```python
        n_rays = packed_info.shape[0]
        ray_indices = unpack_info(packed_info)
        alphas = alpha_fn(t_starts, t_ends, ray_indices.long())
        weights = render_weight_from_alpha(
            packed_info, alphas
        )

        normal_map = accumulate_along_rays(
            weights,
            ray_indices,
            values=sdf_grad_samples,
            n_rays=n_rays,
        )
```

took around 18 minutes, and modifying the `rendering` function and `rgb_alpha_fn` to generate the normal map took around 16 minutes. This version is much less clean, but I think it probably makes sense considering for longer renders there will be a large time savings

I tested this with the Lego scene and DTU 65 using colmap. Things didn't seem to work with colmap and I'm not fully sure why. Heres the gifs of the outputs from both
![lego-normal](https://user-images.githubusercontent.com/25287427/207691459-4966730e-a647-4d5d-8e7a-c438ba61e26b.gif)
![colmap-normal](https://user-images.githubusercontent.com/25287427/207691565-2d16ac00-eaf5-4580-8438-ee01f552b827.gif)

Feels like there's something wrong with the camera parameters after using colmap. Heres an example image from one of the validation runs
![it10000-0](https://user-images.githubusercontent.com/25287427/207692257-7153119f-a03d-4f3a-8c3d-6071d4448b28.png)

lmk your thoughts.




