### PR TITLE
Add indexing parameter to torch meshgrid

### DIFF
--- a/models/geometry.py
+++ b/models/geometry.py
@@ -44,7 +44,7 @@ class MarchingCubeHelper(nn.Module):
     def grid_vertices(self):
         if self.verts is None:
             x, y, z = torch.linspace(*self.points_range, self.resolution), torch.linspace(*self.points_range, self.resolution), torch.linspace(*self.points_range, self.resolution)
-            x, y, z = torch.meshgrid(x, y, z, indexing='xy')
+            x, y, z = torch.meshgrid(x, y, z, indexing='ij')
             verts = torch.cat([x.reshape(-1, 1), y.reshape(-1, 1), z.reshape(-1, 1)], dim=-1).reshape(-1, 3)
             self.verts = verts
         return self.verts

--- a/models/geometry.py
+++ b/models/geometry.py
@@ -44,7 +44,7 @@ class MarchingCubeHelper(nn.Module):
     def grid_vertices(self):
         if self.verts is None:
             x, y, z = torch.linspace(*self.points_range, self.resolution), torch.linspace(*self.points_range, self.resolution), torch.linspace(*self.points_range, self.resolution)
-            x, y, z = torch.meshgrid(x, y, z)
+            x, y, z = torch.meshgrid(x, y, z, indexing='xy')
             verts = torch.cat([x.reshape(-1, 1), y.reshape(-1, 1), z.reshape(-1, 1)], dim=-1).reshape(-1, 3)
             self.verts = verts
         return self.verts


### PR DESCRIPTION
Running the code with a recent version of PyTorch leads to:

```
UserWarning: torch.meshgrid: in an upcoming release, it will be required to pass the indexing argument.
(Triggered internally at ..\aten\src\ATen\native\TensorShape.cpp:3191.)
  return _VF.meshgrid(tensors, **kwargs)  # type: ignore[attr-defined]
```

Next to that, the default indexing mode of `np.meshgrid` and `torch.meshgrid` are different from each other (`xy` vs `ij`), see [the torch meshgrid documentation](https://pytorch.org/docs/master/generated/torch.meshgrid.html#torch-meshgrid) which also includes a warning for this.

I've added the `xy` indexing parameter to the `torch.meshgrid` call which will:

1. Ensure the numpy and torch call to meshgrid have the same indexing mode (since we already have `indexing='xy'` for `np.meshgrid`), even if future changes are made to the defaults (as suggested in the torch docs).
2. Resolve the `UserWarning` that is thrown.

[This issue](https://github.com/pytorch/pytorch/issues/50276) also describes the problem.

If we'd like to use e.g. `indexing='ij'` or something else needs to be changed, please let me know.