### PR TITLE
Update neus.py

### DIFF
--- a/systems/base.py
+++ b/systems/base.py
@@ -59,12 +59,12 @@ class BaseSystem(pl.LightningModule, SaverMixin):
     def on_validation_batch_start(self, batch, batch_idx, dataloader_idx):
         self.dataset = self.trainer.datamodule.val_dataloader().dataset
         self.preprocess_data(batch, 'validation')
-        update_module_step(self.model, self.current_epoch, self.global_step)
+        #update_module_step(self.model, self.current_epoch, self.global_step)
     
     def on_test_batch_start(self, batch, batch_idx, dataloader_idx):
         self.dataset = self.trainer.datamodule.test_dataloader().dataset
         self.preprocess_data(batch, 'test')
-        update_module_step(self.model, self.current_epoch, self.global_step)
+        #update_module_step(self.model, self.current_epoch, self.global_step)
 
     def on_predict_batch_start(self, batch, batch_idx, dataloader_idx):
         self.dataset = self.trainer.datamodule.predict_dataloader().dataset


### PR DESCRIPTION
#this make sure it will be saved after training, if not, when execute test scripts  by setting '--test', this hyperparameter will be set to zero, Which will cause significant drops in performance. When testing ,`on_predict_batch_start` will set `cos_anneal_ratio` to zero, because `self.current_epoch`  equals to zero at the beginning.